### PR TITLE
add user exit event bindings

### DIFF
--- a/src/Callbacks.cc
+++ b/src/Callbacks.cc
@@ -30,6 +30,15 @@ namespace nodeopenni {
     printf("Lost user %d\n", nId);
     context->UserEventAsync("lostuser", nId);
   }
+  
+  void XN_CALLBACK_TYPE
+  User_UserExit(xn::UserGenerator& generator, XnUserID nId,
+                void* pCookie)
+  {
+    Context * context = (Context *) pCookie;
+    assert(context);
+    context->UserEventAsync("userexit", nId);
+  }
 
   void XN_CALLBACK_TYPE
   Pose_Detected(xn::PoseDetectionCapability& pose, const XnChar* strPose,

--- a/src/Callbacks.h
+++ b/src/Callbacks.h
@@ -9,6 +9,9 @@ namespace nodeopenni {
 
   void XN_CALLBACK_TYPE
   User_LostUser(xn::UserGenerator& generator, XnUserID nId, void* pCookie);
+  
+  void XN_CALLBACK_TYPE
+  User_UserExit(xn::UserGenerator& generator, XnUserID nId, void* pCookie);
 
   void XN_CALLBACK_TYPE
   Pose_Detected(xn::PoseDetectionCapability& pose, const XnChar* strPose,

--- a/src/Context.cc
+++ b/src/Context.cc
@@ -269,6 +269,10 @@ namespace nodeopenni {
     status = this->userGenerator_.RegisterUserCallbacks(
       User_NewUser, User_LostUser, this, this->userCallbackHandle_);
     if (hasError(status)) return error("registering user callbacks", status);
+    
+    status = this->userGenerator_.RegisterToUserExit(
+      User_UserExit, this, this->userExitCallbackHandle_);
+    if (hasError(status)) return error("registering user exit callbacks", status);
 
     status = this->userGenerator_.GetPoseDetectionCap().RegisterToPoseCallbacks(
       Pose_Detected, NULL, this, this->poseCallbackHandle_);

--- a/src/Context.h
+++ b/src/Context.h
@@ -60,6 +60,7 @@ namespace nodeopenni {
       
       xn::Context context_;
       XnCallbackHandle userCallbackHandle_;
+      XnCallbackHandle userExitCallbackHandle_;
       XnCallbackHandle poseCallbackHandle_;
       XnCallbackHandle calibrationCallbackHandle_;
       XnCallbackHandle jointConfigurationHandle_;


### PR DESCRIPTION
http://openni.org/documentation/reference/classxn_1_1_user_generator_a868dc984eda50280b5e08ab3eb44383b.html

`skeleton.on('userexit', function(userID) {})` for when a user exits the kinect view (but before the 10 second timeout on `lostuser`
